### PR TITLE
fix: onDelete cascase, set null 설정

### DIFF
--- a/src/api/friend-group/model/friend-group.entity.ts
+++ b/src/api/friend-group/model/friend-group.entity.ts
@@ -12,7 +12,7 @@ export class FriendGroupEntity {
   @PrimaryGeneratedColumn({ name: 'id', comment: '그룹 ID' })
   id: number;
 
-  @ManyToOne(() => Member, (member) => member.id)
+  @ManyToOne(() => Member, (member) => member.id, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'memberId', referencedColumnName: 'id' })
   member: Member;
 

--- a/src/api/friend-list/model/friend-list.entity.ts
+++ b/src/api/friend-list/model/friend-list.entity.ts
@@ -12,7 +12,9 @@ export class FriendListEntity {
   @PrimaryGeneratedColumn({ name: 'id', comment: '친구목록 ID' })
   id: number;
 
-  @ManyToOne(() => FriendGroupEntity, (groupEntity) => groupEntity.id)
+  @ManyToOne(() => FriendGroupEntity, (groupEntity) => groupEntity.id, {
+    onDelete: 'CASCADE',
+  })
   @JoinColumn({ name: 'friendGroupId', referencedColumnName: 'id' })
   group: FriendGroupEntity;
 

--- a/src/api/questionnaire/model/questionnaire-detail.entity.ts
+++ b/src/api/questionnaire/model/questionnaire-detail.entity.ts
@@ -15,6 +15,7 @@ export class QuestionnaireDetailEntity {
   @ManyToOne(
     () => QuestionnaireListEntity,
     (questionnaireList) => questionnaireList.id,
+    { onDelete: 'CASCADE' },
   )
   @JoinColumn({ name: 'questionListId', referencedColumnName: 'id' })
   questionList: QuestionnaireListEntity;

--- a/src/api/questionnaire/model/questionnaire-list.entity.ts
+++ b/src/api/questionnaire/model/questionnaire-list.entity.ts
@@ -12,11 +12,11 @@ export class QuestionnaireListEntity {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @ManyToOne(() => Member, (member) => member.id)
+  @ManyToOne(() => Member, (member) => member.id, { onDelete: 'SET NULL' })
   @JoinColumn({ name: 'fromMemberId', referencedColumnName: 'id' })
   from: Member;
 
-  @ManyToOne(() => Member, (member) => member.id)
+  @ManyToOne(() => Member, (member) => member.id, { onDelete: 'SET NULL' })
   @JoinColumn({ name: 'toMemberId', referencedColumnName: 'id' })
   to: Member;
 


### PR DESCRIPTION
## 👉🏻 PR 내용 (어떤 부분이 달라졌는지 알려주세요!)
- 멤버 삭제 시 -> 멤버가 생성한 그룹 삭제
                       -> 질문지 리스트 from or to "set null"
- 그룹 삭제 시 -> 그룹에 속해있던 친구 리스트 삭제
- 질문 리스트 삭제 시 -> 해당 질문 리스트에 속한 질문 디테일 정보 삭제

## 👉🏻 중점적으로 봐주었으면 하는 부분
- onDelete: 'cascade', onDelete: 'set null' 부분
