### PR TITLE
fix: 친구 프로필 조회시 그룹명이 나오게 변경 및 카카오 아이디 삭제

### DIFF
--- a/src/api/questionnaire/model/profile-read.response.ts
+++ b/src/api/questionnaire/model/profile-read.response.ts
@@ -1,8 +1,16 @@
-import { FriendEntity } from '../../friend/model/friend.entity';
 import { QuestionnaireReadResponse } from './questionnaire-read.response';
 
+export class ProfileDto {
+  id: number;
+  groupName: string;
+  name: string;
+  dateOfBirth: string;
+  isMember: boolean;
+  thumbnailImageUrl: string;
+}
+
 export class ProfileReadResponse {
-  profile: FriendEntity;
+  profile: ProfileDto;
   myAnswer: QuestionnaireReadResponse[];
   friendAnswer: QuestionnaireReadResponse[];
 }

--- a/src/api/questionnaire/questionnaire.module.ts
+++ b/src/api/questionnaire/questionnaire.module.ts
@@ -6,6 +6,7 @@ import { QuestionnaireListEntity } from './model/questionnaire-list.entity';
 import { QuestionnaireDetailEntity } from './model/questionnaire-detail.entity';
 import { Member } from '../member/model/member.entity';
 import { FriendEntity } from '../friend/model/friend.entity';
+import { FriendGroupEntity } from '../friend-group/model/friend-group.entity';
 
 @Module({
   providers: [QuestionnaireService],
@@ -16,6 +17,7 @@ import { FriendEntity } from '../friend/model/friend.entity';
       QuestionnaireDetailEntity,
       Member,
       FriendEntity,
+      FriendGroupEntity,
     ]),
   ],
 })


### PR DESCRIPTION
## 👉🏻 PR 내용 (어떤 부분이 달라졌는지 알려주세요!)
1. 친구 프로필 조회 시 그룹명을 내려주도록 변경
2. 친구 프로필 조회 시 카카오 아이디는 같이 안내려주게 변경

## 👉🏻 중점적으로 봐주었으면 하는 부분

<!-- 변경사항이 큰 경우 집중해야 할 부분, 또는 불안해서 봐주었으면 하는 부분 등 -->
