### PR TITLE
Feat/member

### DIFF
--- a/src/api/alert/interface/alert.interface.ts
+++ b/src/api/alert/interface/alert.interface.ts
@@ -1,10 +1,12 @@
+import { FriendEntity } from 'src/api/friend/model/friend.entity';
+
 export interface IAlertResponse {
   alerts: IFormattedAlert[];
   alertCount: number;
 }
 
 export interface IFormattedAlert {
-  friendId: number;
+  friend: Partial<FriendEntity>;
   questionnaireId: number;
   createdAt: number;
   type: string;

--- a/src/api/alert/service/alert.service.ts
+++ b/src/api/alert/service/alert.service.ts
@@ -77,14 +77,22 @@ export class AlertService {
     alerts.map((alert: AlertEntity) => {
       if (alert.isRequestAlert) {
         formattedAlerts.push({
-          friendId: alert.friend.id,
+          friend: {
+            id: alert.friend.id,
+            name: alert.friend.name,
+            thumbnailImageUrl: alert.friend.thumbnailImageUrl,
+          },
           questionnaireId: alert.questionnaireList.id,
           createdAt: alert.createdAt.getTime(),
           type: 'questionRequests',
         });
       } else {
         formattedAlerts.push({
-          friendId: alert.friend.id,
+          friend: {
+            id: alert.friend.id,
+            name: alert.friend.name,
+            thumbnailImageUrl: alert.friend.thumbnailImageUrl,
+          },
           questionnaireId: alert.questionnaireList.id,
           createdAt: alert.createdAt.getTime(),
           type: 'completedAnswers',

--- a/src/api/member/model/member.entity.ts
+++ b/src/api/member/model/member.entity.ts
@@ -13,4 +13,7 @@ export class Member {
 
   @Column()
   thumbnailImageUrl: string;
+
+  @Column({ nullable: true })
+  defaultGroupId: number;
 }

--- a/src/api/member/service/member.service.ts
+++ b/src/api/member/service/member.service.ts
@@ -43,13 +43,19 @@ export class MemberService {
     member.kakaoId = kakaoData.kakaoId;
     member.name = kakaoData.name;
     member.thumbnailImageUrl = kakaoData.thumbnailImageUrl;
-    member = await this.memberRepository.save(member);
+    await this.memberRepository.save(member);
 
     //기본 그룹 생성
     const defaultFriendGroup: FriendGroupEntity = new FriendGroupEntity();
     defaultFriendGroup.name = '모든 친구들';
     defaultFriendGroup.memberId = member.id;
-    await this.friendGroupRepository.save(defaultFriendGroup);
+    const savedDefaultFriendGroup: FriendGroupEntity =
+      await this.friendGroupRepository.save(defaultFriendGroup);
+
+    await this.memberRepository.update(
+      { id: member.id },
+      { defaultGroupId: savedDefaultFriendGroup.id },
+    );
 
     return member;
   }

--- a/src/api/member/strategy/kakao-login.strategy.ts
+++ b/src/api/member/strategy/kakao-login.strategy.ts
@@ -1,5 +1,5 @@
 import { HttpService } from '@nestjs/axios';
-import { Injectable } from '@nestjs/common';
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { IMember } from '../interface/member.interface';
 
 @Injectable()
@@ -15,7 +15,16 @@ export class KaKaoStrategy {
 
     const kakaoLoginData: any = await this.http
       .get(apiUrl, { headers: header })
-      .toPromise();
+      .toPromise()
+      .catch(() => {
+        throw new HttpException(
+          {
+            statusCode: 1000,
+            message: 'AccessToken Expired',
+          },
+          HttpStatus.UNAUTHORIZED,
+        );
+      });
 
     return {
       kakaoId: kakaoLoginData.data.id,


### PR DESCRIPTION
## 👉🏻 PR 내용 (어떤 부분이 달라졌는지 알려주세요!)
- 카카오 로그인 시 토큰 만료 에러처리
- 멤버 등록 시 멤버 테이블에 기본 그룹 id도 삽입
- 알림 조회 시 친구의 이름, 썸네일도 같이 내려주게 수정

## 👉🏻 중점적으로 봐주었으면 하는 부분

